### PR TITLE
Check if index is out of bound in WindhagerSelectSensor (Issue #21)

### DIFF
--- a/custom_components/windhager/sensor.py
+++ b/custom_components/windhager/sensor.py
@@ -183,4 +183,12 @@ class WindhagerSelectSensor(WindhagerBaseSensor):
         raw_value = self.raw_value
         if raw_value is None:
             return None
+        if not (0 <= raw_value < len(self._options)):
+            _LOGGER.debug(
+                "Invalid status value %s for sensor %s. Must be between 0 and %d",
+                raw_value,
+                self._name,
+                len(self._options) - 1,
+            )
+            return None
         return self._options[raw_value]


### PR DESCRIPTION
fixes #21 

- Added validation for raw_value to ensure it falls within the valid range of options.
- Introduced debug logging for invalid status values to aid in troubleshooting.

Eventually we would need some way to identify the capabilities of each device and ideally create things like the options dictionary dynamically depending on the device instead of hard-coding, but for now this should fix the out of bound errors.